### PR TITLE
Fix2 siocgstamp errors for 2021 rasp pi

### DIFF
--- a/tools/l2test.c
+++ b/tools/l2test.c
@@ -41,6 +41,7 @@
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <linux/sockios.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"

--- a/tools/rctest.c
+++ b/tools/rctest.c
@@ -39,6 +39,8 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <linux/sockios.h>
+
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"


### PR DESCRIPTION
Hi , I had to add #include <linux/sockios.h> in rctest.c and l2test.c to get this to work on a 2021 Raspbian image.
Tested against 
Rasberry Pi OS Lite(32 bit) 
Released 2021-10-30.